### PR TITLE
Add an option to change the game server

### DIFF
--- a/Server.cpp
+++ b/Server.cpp
@@ -1,0 +1,63 @@
+#include "Server.h"
+#include "dinput8.h"
+
+std::string host;
+uint16_t port;
+
+typedef uint32_t(*tConnnect)(void* pProto, char* host, uint16_t port);
+tConnnect oConnect;
+
+uint32_t __declspec(naked) HConnect()
+{
+	__asm {
+		push ebp
+		mov ebp, esp
+		sub esp, __LOCAL_SIZE
+	}
+	
+	const char* hostArg;
+	hostArg  = host.c_str();
+
+	_asm {		
+		push port     // push dword ptr[ebp + 0x04] // port		
+		push hostArg; // push dword ptr[ebp + 0x08] // host
+		call oConnect
+	}
+
+	_asm {
+		mov esp, ebp
+		pop ebp
+		ret 8
+	}
+}
+
+void Hooks::Server()
+{
+	if (config.getBool(L"server", L"enabled", false))
+	{
+		logFile << "Server: enabled" << std::endl;
+
+		host = config.getStrA(L"server", L"host", "dune.dragonsdogma.com");
+		port = config.getUInt(L"server", L"port", 12501);
+
+		BYTE signature[] = {
+			0x83, 0xEC, 0x24,             // sub     esp, 24h
+			0x53,                         // push    ebx
+			0x66, 0x8B, 0x5C, 0x24, 0x30, // mov     bx, [esp+28h+port]
+			0x56,                         // push    esi
+			0x68                          // push    offset nulls_string
+		};		
+
+		BYTE *pOffset;
+		if (!FindSignature("sDDCaProto::connect", signature, &pOffset))
+		{
+			return;
+		}
+
+		CreateHook("sDDCaProto::connect", pOffset, &HConnect, &oConnect);
+	}
+	else
+	{
+		logFile << "Server: disabled" << std::endl;
+	}
+}

--- a/Server.h
+++ b/Server.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace Hooks
+{
+	void Server();
+}

--- a/ddda-dinput8.vcxproj
+++ b/ddda-dinput8.vcxproj
@@ -111,6 +111,7 @@
     <ClCompile Include="iniConfig.cpp" />
     <ClCompile Include="PlayerStats.cpp" />
     <ClCompile Include="SaveBackup.cpp" />
+    <ClCompile Include="Server.cpp" />
     <ClCompile Include="TweakBar.cpp" />
     <ClCompile Include="utils.cpp" />
   </ItemGroup>
@@ -130,6 +131,7 @@
     <ClInclude Include="README.md" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="SaveBackup.h" />
+    <ClInclude Include="Server.h" />
     <ClInclude Include="steam_api.h" />
     <ClInclude Include="TweakBar.h" />
     <ClInclude Include="utils.h" />

--- a/dinput8.cpp
+++ b/dinput8.cpp
@@ -11,6 +11,7 @@
 #include "ItemEditor.h"
 #include "PlayerStats.h"
 #include "Affinity.h"
+#include "Server.h"
 
 typedef HRESULT(WINAPI *tDirectInput8Create)(HINSTANCE inst_handle, DWORD version, const IID& r_iid, LPVOID* out_wrapper, LPUNKNOWN p_unk);
 tDirectInput8Create oDirectInput8Create;
@@ -27,6 +28,7 @@ void Initialize()
 	Hooks::Misc();
 	Hooks::Cheats();
 	Hooks::Affinity();
+	Hooks::Server();
 	if (Hooks::D3D9())
 	{
 		Hooks::PlayerStats();

--- a/dinput8.ini
+++ b/dinput8.ini
@@ -137,6 +137,16 @@ ignoreEquipVocation = off
 ### (e.g. you cant learn dagger skills when using warrior)
 ignoreSkillVocation = off
 
+[server]
+### Server hooks
+###  - Changes the game server that is used for pawn rental and online Ur-Dragon. 
+###  - 'enabled' - turns this feature 'on'/'off'
+###  - 'host' - the name of the server (default: dune.dragonsdogma.com)
+###  - 'port' - the port of the server (default: 12501)
+enabled = off
+host = dune.dragonsdogma.com
+port = 12501
+
 ################################################################################
 #####                               Credits                                #####
 ################################################################################


### PR DESCRIPTION
Hey,

I found your project by coincidence while searching for some dinput8 hook template I needed for Dragon's Dogma.

I'm analyzing the network protocol that is used for pawn rental and the online Ur-Dragon fight at the moment and have been changing the hostname of the game server manually after each launch so far.

This PR adds a new module to specify the hostname/port of the game server by hooking a function that is used to initialize the game's network stack.
