### PR TITLE
Add inclination profile feature

### DIFF
--- a/InGameUI.cpp
+++ b/InGameUI.cpp
@@ -6,6 +6,7 @@
 
 std::vector<void(*)()> content;
 std::vector<void(*)(bool)> windows;
+std::vector<void(*)()> tickHandlers;
 std::vector<std::tuple<LPCSTR, float, ImFont**>> fonts;
 void onLostDevice() { ImGui_ImplDX9_InvalidateDeviceObjects(); }
 void onResetDevice() { ImGui_ImplDX9_CreateDeviceObjects(); }
@@ -37,6 +38,9 @@ void onEndScene()
 	for (size_t i = 0; i < windows.size(); i++)
 		windows[i](inGameUIEnabled);
 	ImGui::Render();
+	
+	for (auto& tick : tickHandlers) 
+		tick();
 }
 
 void renderDDDAFixUI(bool getsInput)
@@ -105,6 +109,7 @@ bool Hooks::InGameUI()
 void Hooks::InGameUIAdd(void(*callback)()) { content.push_back(callback); }
 void Hooks::InGameUIAddWindow(void(*callback)(bool getsInput)) { windows.push_back(callback); }
 void Hooks::InGameUIAddFont(const char *filename, float size_pixels, ImFont **font) { fonts.emplace_back(filename, size_pixels, font); }
+void Hooks::InGameUIAddTickHandler(void(*callback)()) { tickHandlers.push_back(callback); }
 
 namespace ImGui
 {

--- a/InGameUI.h
+++ b/InGameUI.h
@@ -7,6 +7,7 @@ namespace Hooks
 	void InGameUIAddWindow(void(*callback)(bool getsInput));
 	void InGameUIAddInit(void(*callback)());
 	void InGameUIAddFont(const char *filename, float size_pixels, ImFont **font);
+	void InGameUIAddTickHandler(void(*callback)());
 };
 
 namespace ImGui

--- a/InclinationProfiles.cpp
+++ b/InclinationProfiles.cpp
@@ -1,0 +1,180 @@
+#include "stdafx.h"
+#include "InclinationProfiles.h"
+#include "ImGui/imgui_internal.h"
+
+namespace Vocation {
+	enum Enum
+	{
+		Fighter = 0,
+		Strider,
+		Mage,
+		MysticKnight,
+		Assassin,
+		MagickArcher,
+		Warrior,
+		Ranger,
+		Sorcerer,
+		Last = Sorcerer,
+		Length = Last + 1
+	};
+}
+
+namespace Inclination
+{
+	enum Enum
+	{
+		Scather = 0,
+		Medicant,
+		Mitigator,
+		Challenger,
+		Utilitarian,
+		Guardian,
+		Nexus,
+		Pioneer,
+		Acquisitor,
+		Last = Acquisitor,
+		Length = Last + 1
+	};
+}
+
+static char const * const inclinationNames[Inclination::Enum::Length] =
+{
+	"Scather",
+	"Medicant",
+	"Mitigator",
+	"Challenger",
+	"Utilitarian",
+	"Guardian",
+	"Nexus",
+	"Pioneer",
+	"Acquisitor"
+};
+
+static char const * const vocationNames[Vocation::Enum::Length] =
+{
+	"Fighter",
+	"Strider",
+	"Mage",
+	"MysticKnight",
+	"Assassin",
+	"MagickArcher",
+	"Warrior",
+	"Ranger",
+	"Sorcerer"
+};
+
+const bool VALID_PAWN_VOCATIONS[Vocation::Enum::Length] = {
+	true,  // Fighter
+	true,  // Strider
+	true,  // Mage
+	false, // Mystic Knight
+	false, // Assassin
+	false, // Magick Archer
+	true,  // Warrior
+	true,  // Ranger
+	true   // Sorcerer
+};
+
+static bool mainPawnEnabled = false;
+static bool pawn1Enabled = false;
+static bool pawn2Enabled = false;
+
+const float DEFAULT = 500.f;
+
+static float profiles[Vocation::Enum::Length][Inclination::Enum::Length] =
+{
+	{ DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT },
+	{ DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT },
+	{ DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT },
+	{ DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT },
+	{ DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT },
+	{ DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT },
+	{ DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT },
+	{ DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT }
+};
+
+static void applyInclinations(int pawnIndex)
+{
+	const int offset = 0x7F0 + pawnIndex * 0x1660;
+	const int baseOffset = 0xA7000 + offset;
+	const int statsOffset = baseOffset + 0x96C;
+	const int inclinationsOffset = statsOffset + 0x1224;
+	const int vocationOffset = baseOffset + 0x6E0;
+	const UINT32 vocation = *GetBasePtr<UINT32>(vocationOffset) - 1;
+
+	for (int inclination = 0; inclination < Inclination::Enum::Length; ++inclination) 
+	{
+		*(GetBasePtr<float>(inclinationsOffset + inclination * 12)) = profiles[vocation][inclination];
+	}
+}
+
+static void renderInclinationUI()
+{
+	if (ImGui::CollapsingHeader("Inclination Profiles")) 
+	{
+		ImGui::Columns(3, nullptr, false);
+		ImGui::Checkbox("Main Pawn Enabled", &mainPawnEnabled);
+		ImGui::NextColumn();
+		ImGui::Checkbox("Pawn 1 Enabled", &pawn1Enabled);
+		ImGui::NextColumn();
+		ImGui::Checkbox("Pawn 2 Enabled", &pawn2Enabled);
+		ImGui::Columns();
+
+		for (int vocation = 0; vocation < Vocation::Enum::Length; ++vocation) 
+		{
+			if (!VALID_PAWN_VOCATIONS[vocation])
+				continue;
+
+			const char * const vocationName = vocationNames[vocation];
+
+			if (ImGui::TreeNode(vocationName))
+			{
+				for (int inclination = 0; inclination < Inclination::Enum::Length; ++inclination)
+					ImGui::InputFloat(inclinationNames[inclination], &profiles[vocation][inclination], 0.0f, 0.0f, 0);
+
+				ImGui::TreePop();
+			}
+		}
+
+		if (ImGui::Button("Save Settings")) 
+		{
+			for (int vocation = 0; vocation < Vocation::Enum::Length; ++vocation)
+			{
+				if (!VALID_PAWN_VOCATIONS[vocation])
+					continue;
+
+				auto values = std::vector<float>(profiles[vocation], std::end(profiles[vocation]));
+				config.setFloats("inclinationProfiles", vocationNames[vocation], std::move(values), 0);
+				config.setBool("inclinationProfiles", "pawnEnabled", mainPawnEnabled);
+				config.setBool("inclinationProfiles", "pawn1Enabled", pawn1Enabled);
+				config.setBool("inclinationProfiles", "pawn2Enabled", pawn2Enabled);
+			}
+		}
+	}
+
+	if (mainPawnEnabled) 
+		applyInclinations(0);
+	
+	if (pawn1Enabled) 
+		applyInclinations(1);
+	
+	if (pawn2Enabled) 
+		applyInclinations(2);
+}
+
+void Hooks::InclinationProfiles()
+{
+	for (int vocation = 0; vocation < Vocation::Enum::Length; ++vocation)
+	{
+		if (!VALID_PAWN_VOCATIONS[vocation])
+			continue;
+
+		auto values = config.getFloats("inclinationProfiles", vocationNames[vocation]);
+		std::copy(values.begin(), values.end(), profiles[vocation]);
+	}
+
+	mainPawnEnabled = config.getBool("inclinationProfiles", "pawnEnabled", false);
+	pawn1Enabled = config.getBool("inclinationProfiles", "pawn1Enabled", false);
+	pawn2Enabled = config.getBool("inclinationProfiles", "pawn2Enabled", false);
+	InGameUIAdd(renderInclinationUI);
+}

--- a/InclinationProfiles.cpp
+++ b/InclinationProfiles.cpp
@@ -151,14 +151,16 @@ static void renderInclinationUI()
 			}
 		}
 	}
+}
 
-	if (mainPawnEnabled) 
+static void applyInclinations() {
+	if (mainPawnEnabled)
 		applyInclinations(0);
-	
-	if (pawn1Enabled) 
+
+	if (pawn1Enabled)
 		applyInclinations(1);
-	
-	if (pawn2Enabled) 
+
+	if (pawn2Enabled)
 		applyInclinations(2);
 }
 
@@ -177,4 +179,5 @@ void Hooks::InclinationProfiles()
 	pawn1Enabled = config.getBool("inclinationProfiles", "pawn1Enabled", false);
 	pawn2Enabled = config.getBool("inclinationProfiles", "pawn2Enabled", false);
 	InGameUIAdd(renderInclinationUI);
+	InGameUIAddTickHandler(applyInclinations);
 }

--- a/InclinationProfiles.h
+++ b/InclinationProfiles.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace Hooks
+{
+	void InclinationProfiles();
+}

--- a/PlayerStats.cpp
+++ b/PlayerStats.cpp
@@ -233,7 +233,7 @@ void renderStatsParty(const char *label, int offset, bool *respecShow)
 		ImGui::TreePop();
 	}
 
-	if (offset && ImGui::TreeNode("Inclinations"))//main pawn
+	if (offset && ImGui::TreeNode("Inclinations")) // pawn
 	{
 		int inclinationsOffset = statsOffset + 0x1224;
 		ImGui::InputFloat("Scather", GetBasePtr<float>(inclinationsOffset += 0));

--- a/ddda-dinput8.vcxproj
+++ b/ddda-dinput8.vcxproj
@@ -100,6 +100,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="DamageLog.cpp" />
+    <ClCompile Include="InclinationProfiles.cpp" />
     <ClCompile Include="InGameUI.cpp" />
     <ClCompile Include="ImGui\imgui.cpp">
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\stdafx.h</PrecompiledHeaderFile>
@@ -133,6 +134,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="DamageLog.h" />
+    <ClInclude Include="InclinationProfiles.h" />
     <ClInclude Include="InGameUI.h" />
     <ClInclude Include="ImGui\imconfig.h" />
     <ClInclude Include="ImGui\imgui.h" />

--- a/ddda-dinput8.vcxproj.filters
+++ b/ddda-dinput8.vcxproj.filters
@@ -74,6 +74,9 @@
     <ClCompile Include="DamageLog.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="InclinationProfiles.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="dinput8.h">
@@ -151,6 +154,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="DamageLog.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="InclinationProfiles.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/dinput8.cpp
+++ b/dinput8.cpp
@@ -12,6 +12,7 @@
 #include "Portcrystals.h"
 #include "WeaponSets.h"
 #include "DamageLog.h"
+#include "InclinationProfiles.h"
 
 typedef HRESULT(WINAPI *tDirectInput8Create)(HINSTANCE inst_handle, DWORD version, const IID& r_iid, LPVOID* out_wrapper, LPUNKNOWN p_unk);
 tDirectInput8Create oDirectInput8Create = nullptr;
@@ -45,6 +46,7 @@ void InitHooks()
 		Hooks::ItemEditor();
 		Hooks::InGameClock();
 		Hooks::DamageLog();
+		Hooks::InclinationProfiles();
 	}
 }
 

--- a/dinput8.ini
+++ b/dinput8.ini
@@ -220,6 +220,25 @@ enabled = off
 host = dune.dragonsdogma.com
 port = 12501
 
+[inclinationProfiles]
+### Lock the inclinations of the main pawn to the configured profile for its class
+pawnEnabled = off
+
+### Lock the inclinations of first hired pawn to the configured profile for its class
+pawn1Enabled = off
+
+### Lock the inclinations of second hired pawn to the configured profile for its class
+pawn2Enabled = off
+
+### Any enabled pawn will have its inclinations locked to the values below for its corresponding class.
+### Scather; Medicant; Mitigator; Challenger; Utilitarian; Guardian; Nexus; Pioneer; Acquisitor
+Fighter = 500;500;500;500;500;500;500;500;500
+Ranger = 500;500;500;500;500;500;500;500;500
+Sorcerer = 500;500;500;500;500;500;500;500;500
+Strider = 500;500;500;500;500;500;500;500;500
+Warrior = 500;500;500;500;500;500;500;500;500
+Mage = 500;500;500;500;500;500;500;500;500
+
 ################################################################################
 #####                               Credits                                #####
 ################################################################################

--- a/iniConfig.cpp
+++ b/iniConfig.cpp
@@ -227,5 +227,5 @@ void iniConfig::setFloats(LPCSTR section, LPCSTR key, std::vector<float> list, i
 		out << f;
 	}
 
-	setStr(section, key, std::move(out.str()));
+	setStr(section, key, out.str());
 }

--- a/iniConfig.cpp
+++ b/iniConfig.cpp
@@ -1,4 +1,8 @@
 ﻿#include "stdafx.h"
+#include <string>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
 #include "iniConfig.h"
 
 iniConfig::iniConfig(LPCSTR fileName)
@@ -210,14 +214,18 @@ void iniConfig::setInts(LPCSTR section, LPCSTR key, std::vector<int> list) const
 	setStr(section, key, str);
 }
 
-void iniConfig::setFloats(LPCSTR section, LPCSTR key, std::vector<float> list) const
+void iniConfig::setFloats(LPCSTR section, LPCSTR key, std::vector<float> list, int precision) const
 {
-	string str;
-	for (size_t i = 0; i < list.size(); i++)
+	std::ostringstream out;
+	if (precision != -1) 
+		out << std::setprecision(precision);
+
+	for (const float &f : list) 
 	{
-		str += std::to_string(list[i]);
-		if (i < list.size() - 1)
-			str += ";";
+		if (&f != &list[0])
+			out << ";";
+		out << f;
 	}
-	setStr(section, key, str);
+
+	setStr(section, key, std::move(out.str()));
 }

--- a/iniConfig.h
+++ b/iniConfig.h
@@ -30,5 +30,5 @@ public:
 	void setBool(LPCSTR section, LPCSTR key, bool value) const;
 	void setEnum(LPCSTR section, LPCSTR key, int value, std::pair<int, LPCSTR> map[], int size) const;
 	void setInts(LPCSTR section, LPCSTR key, std::vector<int> list) const;
-	void setFloats(LPCSTR section, LPCSTR key, std::vector<float> list) const;
+	void setFloats(LPCSTR section, LPCSTR key, std::vector<float> list, int precision = -1) const;
 };


### PR DESCRIPTION
I found constantly using the stat editor to reset my pawn's inclinations to be annoying, especially when changing the pawn's vocations.

This adds a feature that allows you to specify per-class inclinations that should be applied to pawns. Once enabled, pawns are locked to the configured inclinations for their current class. The feature can be enabled separately for each pawn.

If you change your pawn's vocation (or hire a new pawn), then the profile for the corresponding vocation will be automatically applied.

![inclination-profiles](https://user-images.githubusercontent.com/15098250/39498466-3a562844-4d76-11e8-89ac-3ea14b417aa4.png)
